### PR TITLE
Pull from Dev branch ahead of 1.0.4.2 release 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,13 @@
 # To do
 
 ## Issues
+- Army map overlay needs hotkeys.
+- Mercenaries should not be able to manage armies they are a part of, add members to it, etc.
 - ~~When adding into an existing game, mercenaries part of a kingdom already won't have a correlating contract, causing crashing.~~
 - ~~As a prisoner, opening kingdom screen causes a crash.~~
-- Army map overlay needs hotkeys.
+- ~~When the leader of an army is changed to the player while the player is a member of that army, the army map overlay breaks and fails to display the army members.~~
+- ~~Parties not yet gathered in the army should not be put in a disorganized state when moved between armies, such as during a leader change or split.~~
+
 
 ## General
 - Campaign time should slowly pass during player battles, allowing the possibility of reinforcements.
@@ -15,26 +19,22 @@
 - Ability for an NPC clan to become independent to form their own faction with certain conditions.
 - Backwards compatibility
 - MCM Options: Armies besiege AI, Additional mercenary clans
-- ~~Seasonal warfare; Winter should be spent stockpiling and focusing on keeping the economy stable, and warfare should resume in the spring. Very aggressive rulers or commanders may still take the risk that comes with prosecuting a winter war.~~ Experimentally added in 1.0.4
-- ~~Automatic cohesion maintenance for individual armies, paid by player.~~ Added in 1.0.4
 - Fully replenish cohesion of all active armies in the kingdom from the map, paid by player.
 - Armies can deteriorate allowing room for nomads and other migrants to proliferate and take over regions ? Similar to the migration of the Visigoths / Huns around the fall of Rome
 
 ## Army Overhaul
-- When the leader of an army is changed to the player while the player is a member of that army, the army map overlay breaks and fails to display the army members.
-- ~~Parties not yet gathered in the army should not be put in a disorganized state when moved between armies, such as during a leader change or split.~~
-- Mercenaries should not be able to manage armies they are a part of, add members to it, etc.
+- ~~Automatic cohesion maintenance for individual armies, paid by player.~~ Added in 1.0.4
 
 ## Battle Overhaul
 - Arrows should pierce through shields in certain conditions, with some damage dealt to the character and the possibility to stagger them.
 
 ## Mercenary Overhaul
-- ~~Add remaining contract time to the Mercenary panel.~~
 - Factions should be less inclined to horde troops - especially in peacetime - in order to pay for mercenaries in wartime.
 - Mercenaries should not declare wars on factions over time, currently they do for unknown reasons but do not on game start as intended.
-- Slider for mercenary clan spawns on game start.
 - Ability to form a mercenary company.
 - Ability to join a mercenary company.
+- ~~Slider for mercenary clan spawns on game start.~~ Added in 1.0.3
+- ~~Add remaining contract time to the Mercenary panel.~~ Added in 1.0.3
 
 ## Prisoners Overhaul
 - Prisoners should disperse back to enemy lord(s) when escaped, set free or ransomed.
@@ -43,3 +43,4 @@
 ## World Overhaul
 - War should constrain economies in a more realistic way; Prices in a war-torn areas of the map should have increased prices especially on necessities.
 - War should also cause migration, resulting in recruiting difficulty in war-torn areas of the map and surpluses in peaceful ones.
+- ~~Seasonal warfare; Winter should be spent stockpiling and focusing on keeping the economy stable, and warfare should resume in the spring. Very aggressive rulers or commanders may still take the risk that comes with prosecuting a winter war.~~ Experimentally added in 1.0.4

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 ## Issues
 - ~~When adding into an existing game, mercenaries part of a kingdom already won't have a correlating contract, causing crashing.~~
 - ~~As a prisoner, opening kingdom screen causes a crash.~~
+- Army map overlay needs hotkeys.
 
 ## General
 - Campaign time should slowly pass during player battles, allowing the possibility of reinforcements.
@@ -14,13 +15,12 @@
 - Ability for an NPC clan to become independent to form their own faction with certain conditions.
 - Backwards compatibility
 - MCM Options: Armies besiege AI, Additional mercenary clans
-- Seasonal warfare; Winter should be spent stockpiling and focusing on keeping the economy stable, and warfare should resume in the spring. Very aggressive rulers or commanders may still take the risk that comes with prosecuting a winter war.
-- Automatic cohesion maintenance for individual armies, paid by player.
+- ~~Seasonal warfare; Winter should be spent stockpiling and focusing on keeping the economy stable, and warfare should resume in the spring. Very aggressive rulers or commanders may still take the risk that comes with prosecuting a winter war.~~ Experimentally added in 1.0.4
+- ~~Automatic cohesion maintenance for individual armies, paid by player.~~ Added in 1.0.4
 - Fully replenish cohesion of all active armies in the kingdom from the map, paid by player.
 - Armies can deteriorate allowing room for nomads and other migrants to proliferate and take over regions ? Similar to the migration of the Visigoths / Huns around the fall of Rome
 
 ## Army Overhaul
-- Army map overlay needs hotkeys.
 - When the leader of an army is changed to the player while the player is a member of that army, the army map overlay breaks and fails to display the army members.
 - ~~Parties not yet gathered in the army should not be put in a disorganized state when moved between armies, such as during a leader change or split.~~
 - Mercenaries should not be able to manage armies they are a part of, add members to it, etc.

--- a/TODO.md
+++ b/TODO.md
@@ -19,14 +19,14 @@
 - Fully replenish cohesion of all active armies in the kingdom from the map, paid by player.
 - Armies can deteriorate allowing room for nomads and other migrants to proliferate and take over regions ? Similar to the migration of the Visigoths / Huns around the fall of Rome
 
-## Battle Overhaul
-- Arrows should pierce through shields in certain conditions, with some damage dealt to the character and the possibility to stagger them.
-
 ## Army Overhaul
 - Army map overlay needs hotkeys.
 - When the leader of an army is changed to the player while the player is a member of that army, the army map overlay breaks and fails to display the army members.
 - ~~Parties not yet gathered in the army should not be put in a disorganized state when moved between armies, such as during a leader change or split.~~
 - Mercenaries should not be able to manage armies they are a part of, add members to it, etc.
+
+## Battle Overhaul
+- Arrows should pierce through shields in certain conditions, with some damage dealt to the character and the possibility to stagger them.
 
 ## Mercenary Overhaul
 - ~~Add remaining contract time to the Mercenary panel.~~
@@ -39,3 +39,7 @@
 ## Prisoners Overhaul
 - Prisoners should disperse back to enemy lord(s) when escaped, set free or ransomed.
 - Army & Party leaders should be able to surrender during battle and their party members would automatically rejoin them when dispersed from prison. INFO: This would be separate from OrderWOPower's Surrender Tweaks in that the surrendering would happen DURING a battle, once the other side comes to a realization they cannot win.
+
+## World Overhaul
+- War should constrain economies in a more realistic way; Prices in a war-torn areas of the map should have increased prices especially on necessities.
+- War should also cause migration, resulting in recruiting difficulty in war-torn areas of the map and surpluses in peaceful ones.

--- a/src/Bannerlord.Warfare/Behaviors/MercenaryBehavior.cs
+++ b/src/Bannerlord.Warfare/Behaviors/MercenaryBehavior.cs
@@ -52,7 +52,7 @@ namespace Warfare.Behaviors
                     Clan clan = clans.ElementAt(j);
                     foreach (Hero hero in clan.Heroes)
                     {
-                        if (!hero.IsDead && hero != Hero.MainHero)
+                        if (!Settings.Current.MaintainVanillaNames && !hero.IsDead && hero != Hero.MainHero)
                         {
                             TextObject name = new TextObject(hero.Name.ToString().Split(' ').FirstOrDefault());
                             hero.SetName(name, name);
@@ -60,13 +60,19 @@ namespace Warfare.Behaviors
                         hero.Gold = 0;
                         GiveGoldAction.ApplyBetweenCharacters(null, hero, GetStartingGold());
                     }
-                    clan.GetType().GetField("_banner", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(clan, Banner.CreateRandomClanBanner(MBRandom.RandomInt()));
-                    clan.GetType().GetProperty("EncyclopediaText", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).SetValue(clan, new TextObject());
+                    if (!Settings.Current.MaintainVanillaBanners)
+                    {
+                        clan.GetType().GetField("_banner", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(clan, Banner.CreateRandomClanBanner(MBRandom.RandomInt()));
+                    }
                     if (minorCulture != null && clan.Culture == minorCulture)
                     {
                         clan.Culture = culture;
                     }
-                    ChangeClanName(clan);
+                    if (!Settings.Current.MaintainVanillaNames)
+                    {
+                        clan.GetType().GetProperty("EncyclopediaText", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).SetValue(clan, new TextObject());
+                        ChangeClanName(clan);
+                    }
                     clan.ResetClanRenown();
                     clan.AddRenown(GetStartingRenown(clan));
                     RecruitTroops(clan, true);

--- a/src/Bannerlord.Warfare/Settings.cs
+++ b/src/Bannerlord.Warfare/Settings.cs
@@ -28,6 +28,54 @@ namespace Warfare
         [SettingPropertyGroup(GeneralHeader, GroupOrder = 0)]
         public bool ModifyWinterWarfareTendency { get; set; } = false;
 
+        [SettingPropertyBool("{=IcF3bsNX}Enable Cohesion Change", Order = 0, RequireRestart = false, HintText = "{=PKL1vtQN}Allows cohesion to be depleted over time. Default: Enabled")]
+        [SettingPropertyGroup(ArmiesHeader, GroupOrder = 10)]
+        public bool EnableCohesionChange { get; set; } = true;
+
+        [SettingPropertyBool("{=SwU5nhKX}Enable Modify Maximum Battlefield Agents", Order = 1, RequireRestart = false, HintText = "{=hIbdHP2A}Allows the maximum battlefield agents modifier to be set using the mod, which overrides the vanilla setting which ranges from 200-1000. Default: Disabled")]
+        [SettingPropertyGroup(ArmiesHeader, GroupOrder = 10)]
+        public bool EnableModifyMaximumBattlefieldAgents { get; set; } = false;
+
+        [SettingPropertyInteger("{=uqq9P40V}Maximum Battlefield Agents", 1000, 2000, Order = 2, RequireRestart = false, HintText = "{=gNUoN5Ia}Sets the maximum number of total agents on battles. NOTE: Setting this too high can result in crashes! It is recommended to test a field battle using lots of cavalary if you plan to set this higher than 1000. Overrides the Battle Size setting in the vanilla Performance settings section. Default: 1000")]
+        [SettingPropertyGroup(ArmiesHeader, GroupOrder = 10)]
+        public int MaximumBattlefieldAgents { get; set; } = 1000;
+
+        [SettingPropertyBool("{=pLTpHLi0}Modify Army Besiege AI", Order = 0, RequireRestart = false, HintText = "{=V2B0f9AM}Modifies the army besieging AI to prevent AI armies from moving to siege a settlement already being besieged by another army, based upon the power difference in besieged and besieger power. This minimizes the chance of a player siege being taken over by an AI. There will tend to be multiple war fronts / theaters with this enabled. Default: Enabled")]
+        [SettingPropertyGroup(ArmyAIHeader, GroupOrder = 0)]
+        public bool ModifyArmyBesiegeAI { get; set; } = true;
+
+        [SettingPropertyInteger("{=9vo8PxtF}Minimum Fiefs To Modify Army Besiege AI", 1, 10, Order = 1, RequireRestart = false, HintText = "{=KAnYH0W2}Modifies the army besieging AI only if the target faction has at least the specified number of fiefs. This has no effect if 'Modify Army Besiege AI' is Disabled. Default: 3")]
+        [SettingPropertyGroup(ArmyAIHeader, GroupOrder = 0)]
+        public int ModifyArmyBesiegeAIMinimumFiefs { get; set; } = 3;
+
+        [SettingPropertyInteger("{=hQ6ROvxB}Time To Prevent Army Besiege AI (Hours)", 1, 168, Order = 2, RequireRestart = false, HintText = "{=OGME2Ekq}Sets the amount of time in hours that the AI will be prevented from attempting to besiege a settlement being besieged by another army. This has no effect if 'Modify Army Besiege AI' is Disabled. Default: 24")]
+        [SettingPropertyGroup(ArmyAIHeader, GroupOrder = 0)]
+        public int TimeToPreventArmyBesiegeAIHours { get; set; } = 24;
+
+        [SettingPropertyFloatingInteger("{=WWq8ftLX}Defensive tendency for defensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 0, RequireRestart = false, HintText = "{=0iHIh4HO}Sets the defensive tendency for armies using the defensive strategy. Default: 110%")]
+        [SettingPropertyGroup(ArmyStrategyHeader, GroupOrder = 10)]
+        public float DefensiveTendencyDefensiveStrategy { get; set; } = 1.1f;
+
+        [SettingPropertyFloatingInteger("{=1raR5mTu}Offensive tendency for defensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 1, RequireRestart = false, HintText = "{=b8IWHpUU}Sets the offensive tendency for armies using the defensive strategy. Default: 65%")]
+        [SettingPropertyGroup(ArmyStrategyHeader, GroupOrder = 10)]
+        public float OffensiveTendencyDefensiveStrategy { get; set; } = 0.65f;
+
+        [SettingPropertyFloatingInteger("{=1UJ78ara}Chase tendency for defensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 2, RequireRestart = false, HintText = "{=q553aa8M}Sets the party chase tendency for armies using the offensive strategy. Default: 120%")]
+        [SettingPropertyGroup(ArmyStrategyHeader, GroupOrder = 10)]
+        public float ChaseTendencyDefensiveStrategy { get; set; } = 1.2f;
+
+        [SettingPropertyFloatingInteger("{=h0LG1AKQ}Defensive tendency for offensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 3, RequireRestart = false, HintText = "{=QzPoBQWF}Sets the defensive tendency for armies using the offensive strategy. Default: 65%")]
+        [SettingPropertyGroup(ArmyStrategyHeader, GroupOrder = 10)]
+        public float DefensiveTendencyOffensiveStrategy { get; set; } = 0.65f;
+
+        [SettingPropertyFloatingInteger("{=fV3Kvnbu}Offensive tendency for offensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 4, RequireRestart = false, HintText = "{=Zs9y8UIJ}Sets the offensive tendency for armies using the offensive strategy. Default: 110%")]
+        [SettingPropertyGroup(ArmyStrategyHeader, GroupOrder = 10)]
+        public float OffensiveTendencyOffensiveStrategy { get; set; } = 1.1f;
+
+        [SettingPropertyFloatingInteger("{=dpUAnwfP}Chase tendency for offensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 5, RequireRestart = false, HintText = "{=zT85SDWT}Sets the party chase tendency for armies using the offensive strategy. Default: 80%")]
+        [SettingPropertyGroup(ArmyStrategyHeader, GroupOrder = 10)]
+        public float ChaseTendencyOffensiveStrategy { get; set; } = 0.8f;
+
         [SettingPropertyDropdown("{=srjDu3DL}Mercenary Contract Type", Order = 0, RequireRestart = false, HintText = "{=jzipGOog}The mercenary contract length. Effects the contract cost as it is relative to daily wages. Default: Seasonal")]
         [SettingPropertyGroup(MercenariesHeader, GroupOrder = 20)]
         public Dropdown<string> MercenaryContractType { get; } = new(new string[] { "{=EVEAh6Eg}Weekly", "{=dIZZ55i0}Seasonal", "{=pYZ9blgd}Annual" }, 1);
@@ -52,61 +100,21 @@ namespace Warfare
         [SettingPropertyGroup(MercenariesHeader, GroupOrder = 20)]
         public int MinimumWarsToHireMercenaries { get; set; } = 1;
 
-        [SettingPropertyBool("{=rjjUIti9}Spawn Additional Mercenaries", Order = 6, RequireRestart = false, HintText = "{=qTfVx8hh}Spawns more mercenaries when starting a new game than vanilla includes. This will make the world livelier and give more contract possiblities. The mod is balanced around this being enabled. Default: Enabled")]
-        [SettingPropertyGroup(MercenariesHeader, GroupOrder = 20)]
-        public bool SpawnAdditionalMercenaries { get; set; } = true;
-
-        [SettingPropertyInteger("{=JrsHuJB0}Mercenary Clans Per Culture", 0, 10, Order = 7, RequireRestart = false, HintText = "{=b1YjXBJA}Spawns more mercenary clans for each culture until the selected threshold is reached. Default: 5")]
+        [SettingPropertyInteger("{=JrsHuJB0}Mercenary Clans Per Culture", 0, 10, Order = 6, RequireRestart = false, HintText = "{=b1YjXBJA}Spawns more mercenary clans for each culture until the selected threshold is reached. Default: 5")]
         [SettingPropertyGroup(MercenariesHeader, GroupOrder = 20)]
         public int MercenaryClansPerCulture { get; set; } = 5;
 
-        [SettingPropertyBool("{=IcF3bsNX}Enable Cohesion Change", Order = 0, RequireRestart = false, HintText = "{=PKL1vtQN}Allows cohesion to be depleted over time. Default: Enabled")]
-        [SettingPropertyGroup(ArmiesHeader, GroupOrder = 10)]
-        public bool EnableCohesionChange { get; set; } = true;
+        [SettingPropertyBool("{=rjjUIti9}Spawn Additional Mercenaries", Order = 7, RequireRestart = false, HintText = "{=qTfVx8hh}Spawns more mercenaries when starting a new game than vanilla includes. This will make the world livelier and give more contract possiblities. The mod is balanced around this being enabled. Default: Enabled")]
+        [SettingPropertyGroup(MercenariesHeader, GroupOrder = 20)]
+        public bool SpawnAdditionalMercenaries { get; set; } = true;
 
-        [SettingPropertyBool("{=SwU5nhKX}Enable Modify Maximum Battlefield Agents", Order = 1, RequireRestart = false, HintText = "{=hIbdHP2A}Allows the maximum battlefield agents modifier to be set using the mod, which overrides the vanilla setting which ranges from 200-1000. Default: Disabled")]
-        [SettingPropertyGroup(ArmiesHeader, GroupOrder = 10)]
-        public bool EnableModifyMaximumBattlefieldAgents { get; set; } = false;
+        [SettingPropertyBool("{=rmugSIvK}Maintain Vanilla Names", Order = 8, RequireRestart = false, HintText = "{=BdXcxPA6}When the vanilla mercenary clans are spawned in a new game, they will use vanilla naming conventions for the clan and their members. By default, this mod renames them to maintain consistency with additionally spawned mercenaries. The additional mercenaries will maintain Warfare naming conventions. Default: Disabled")]
+        [SettingPropertyGroup(MercenariesHeader, GroupOrder = 20)]
+        public bool MaintainVanillaNames { get; set; } = false;
 
-        [SettingPropertyInteger("{=uqq9P40V}Maximum Battlefield Agents", 1000, 2000, Order = 2, RequireRestart = false, HintText = "{=gNUoN5Ia}Sets the maximum number of total agents on battles. NOTE: Setting this too high can result in crashes! It is recommended to test a field battle using lots of cavalary if you plan to set this higher than 1000. Overrides the Battle Size setting in the vanilla Performance settings section. Default: 1000")]
-        [SettingPropertyGroup(ArmiesHeader, GroupOrder = 10)]
-        public int MaximumBattlefieldAgents { get; set; } = 1000;
-
-        [SettingPropertyBool("{=pLTpHLi0}Modify Army Besiege AI", Order = 0, RequireRestart = false, HintText = "{=V2B0f9AM}Modifies the army besieging AI to prevent AI armies from moving to siege a settlement already being besieged by another army, based upon the power difference in besieged and besieger power. This minimizes the chance of a player siege being taken over by an AI. There will tend to be multiple war fronts / theaters with this enabled. Default: Enabled")]
-        [SettingPropertyGroup(ArmyAIHeader)]
-        public bool ModifyArmyBesiegeAI { get; set; } = true;
-
-        [SettingPropertyInteger("{=9vo8PxtF}Minimum Fiefs To Modify Army Besiege AI", 1, 10, Order = 1, RequireRestart = false, HintText = "{=KAnYH0W2}Modifies the army besieging AI only if the target faction has at least the specified number of fiefs. This has no effect if 'Modify Army Besiege AI' is Disabled. Default: 3")]
-        [SettingPropertyGroup(ArmyAIHeader)]
-        public int ModifyArmyBesiegeAIMinimumFiefs { get; set; } = 3;
-
-        [SettingPropertyInteger("{=hQ6ROvxB}Time To Prevent Army Besiege AI (Hours)", 1, 168, Order = 2, RequireRestart = false, HintText = "{=OGME2Ekq}Sets the amount of time in hours that the AI will be prevented from attempting to besiege a settlement being besieged by another army. This has no effect if 'Modify Army Besiege AI' is Disabled. Default: 24")]
-        [SettingPropertyGroup(ArmyAIHeader)]
-        public int TimeToPreventArmyBesiegeAIHours { get; set; } = 24;
-
-        [SettingPropertyFloatingInteger("{=WWq8ftLX}Defensive tendency for defensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 0, RequireRestart = false, HintText = "{=0iHIh4HO}Sets the defensive tendency for armies using the defensive strategy. Default: 110%")]
-        [SettingPropertyGroup(ArmyStrategyHeader)]
-        public float DefensiveTendencyDefensiveStrategy { get; set; } = 1.1f;
-
-        [SettingPropertyFloatingInteger("{=1raR5mTu}Offensive tendency for defensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 1, RequireRestart = false, HintText = "{=b8IWHpUU}Sets the offensive tendency for armies using the defensive strategy. Default: 65%")]
-        [SettingPropertyGroup(ArmyStrategyHeader)]
-        public float OffensiveTendencyDefensiveStrategy { get; set; } = 0.65f;
-
-        [SettingPropertyFloatingInteger("{=1UJ78ara}Chase tendency for defensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 2, RequireRestart = false, HintText = "{=q553aa8M}Sets the party chase tendency for armies using the offensive strategy. Default: 120%")]
-        [SettingPropertyGroup(ArmyStrategyHeader)]
-        public float ChaseTendencyDefensiveStrategy { get; set; } = 1.2f;
-
-        [SettingPropertyFloatingInteger("{=h0LG1AKQ}Defensive tendency for offensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 3, RequireRestart = false, HintText = "{=QzPoBQWF}Sets the defensive tendency for armies using the offensive strategy. Default: 65%")]
-        [SettingPropertyGroup(ArmyStrategyHeader)]
-        public float DefensiveTendencyOffensiveStrategy { get; set; } = 0.65f;
-
-        [SettingPropertyFloatingInteger("{=fV3Kvnbu}Offensive tendency for offensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 4, RequireRestart = false, HintText = "{=Zs9y8UIJ}Sets the offensive tendency for armies using the offensive strategy. Default: 110%")]
-        [SettingPropertyGroup(ArmyStrategyHeader)]
-        public float OffensiveTendencyOffensiveStrategy { get; set; } = 1.1f;
-
-        [SettingPropertyFloatingInteger("{=dpUAnwfP}Chase tendency for offensive Army Strategy", 0.0f, 5.0f, "#0%", Order = 5, RequireRestart = false, HintText = "{=zT85SDWT}Sets the party chase tendency for armies using the offensive strategy. Default: 80%")]
-        [SettingPropertyGroup(ArmyStrategyHeader)]
-        public float ChaseTendencyOffensiveStrategy { get; set; } = 0.8f;
+        [SettingPropertyBool("{=U9sTpxGe}Maintain Vanilla Banners", Order = 9, RequireRestart = false, HintText = "{=6Tsx3ntW}When the vanilla mercenary clans are spawned in a new game, they will use vanilla banners. By default, this mod shuffles them to maintain consistency with additionally spawned mercenaries. The additional mercenaries will maintain Warfare banner conventions. Default: Disabled")]
+        [SettingPropertyGroup(MercenariesHeader, GroupOrder = 20)]
+        public bool MaintainVanillaBanners { get; set; } = false;
 
         [SettingPropertyBool("{=MUSHsQr8}Logging", Order = 0, RequireRestart = false, HintText = "{=Wa3DouAN}Enables logs for testing and reporting purposes. Enable this only if Author requests a log during issue reproduction. Default: Disabled")]
         [SettingPropertyGroup(OtherHeader, GroupOrder = 100)]

--- a/src/Bannerlord.Warfare/ViewModels/ArmyManagement/WarfareArmyManagementItemVM.cs
+++ b/src/Bannerlord.Warfare/ViewModels/ArmyManagement/WarfareArmyManagementItemVM.cs
@@ -232,6 +232,10 @@ namespace Warfare.ViewModels.ArmyManagement
                     _eligibilityReason = new TextObject("{=kNW1qYSi}{HERO.NAME} is already leading another army.");
                     _eligibilityReason.SetCharacterProperties("HERO", Party.LeaderHero.CharacterObject);
                 }
+                else if (Party.Army != null && Party == MobileParty.MainParty && Party.Army.Parties.Contains(MobileParty.MainParty))
+                {
+                    _eligibilityReason = new TextObject("{=d2GgQuYI}You must leave the party before becoming it's new leader.");
+                }
                 else
                 {
                     isEligible = true;

--- a/src/Bannerlord.Warfare/ViewModels/Military/KingdomMilitaryVM.cs
+++ b/src/Bannerlord.Warfare/ViewModels/Military/KingdomMilitaryVM.cs
@@ -886,6 +886,11 @@ namespace Warfare.ViewModels.Military
                     explanation.SetCharacterProperties("HERO", hero.CharacterObject);
                     return false;
                 }
+                if (hero.PartyBelongedTo == MobileParty.MainParty && hero.PartyBelongedTo.Army.Parties.Contains(MobileParty.MainParty))
+                {
+                    explanation = new TextObject("{=d2GgQuYI}You must leave the party before becoming it's new leader.");
+                    return false;
+                }
             }
             if (hero.IsPrisoner)
             {

--- a/src/Bannerlord.Warfare/ViewModels/Military/KingdomMilitaryVM.cs
+++ b/src/Bannerlord.Warfare/ViewModels/Military/KingdomMilitaryVM.cs
@@ -433,7 +433,7 @@ namespace Warfare.ViewModels.Military
 
             if (!CurrentSelectedArmy.Army.Parties.Contains(MobileParty.MainParty) && Hero.MainHero != CurrentSelectedArmy.Army.Kingdom.Leader)
             {
-                disabledReason = new TextObject("{=kBGlNylO}You cannot manage an army unless you are the faction leader or an army member.");
+                disabledReason = new TextObject("{=kBGlNylO}You cannot manage an army unless you are the army leader, faction leader or an army member.");
                 return false;
             }
 

--- a/src/Bannerlord.Warfare/_Module/ModuleData/Languages/EN/module_strings.xml
+++ b/src/Bannerlord.Warfare/_Module/ModuleData/Languages/EN/module_strings.xml
@@ -96,6 +96,10 @@
 		<string id="JIHCDNcu" text="The minimum amount of wars for AI clans to hire mercenaries. Default: 1" />
 		<string id="rjjUIti9" text="Spawn Additional Mercenaries" />
 		<string id="qTfVx8hh" text="Spawns more mercenaries when starting a new game than vanilla includes. This will make the world livelier and give more contract possiblities. The mod is balanced around this being enabled. Default: Enabled" />
+		<string id="rmugSIvK" text="Maintain Vanilla Names" />
+		<string id="BdXcxPA6" text="When the vanilla mercenary clans are spawned in a new game, they will use vanilla naming conventions. By default, this mod renames them to maintain consistency with additionally spawned mercenaries. The additional mercenaries will maintain Warfare naming conventions. Default: Disabled" />
+		<string id="U9sTpxGe" text="Maintain Vanilla Banners" />
+		<string id="6Tsx3ntW" text="When the vanilla mercenary clans are spawned in a new game, they will use vanilla banners. By default, this mod shuffles them to maintain consistency with additionally spawned mercenaries. The additional mercenaries will maintain Warfare banner conventions. Default: Disabled" />
 		<string id="SwU5nhKX" text="Enable Modify Maximum Battlefield Agents" />
 		<string id="hIbdHP2A" text="Allows the maximum battlefield agents modifier to be set using the mod, which overrides the vanilla setting which ranges from 200-1000. Default: Disabled" />
 		<string id="uqq9P40V" text="Maximum Battlefield Agents" />

--- a/src/Bannerlord.Warfare/_Module/ModuleData/Languages/EN/module_strings.xml
+++ b/src/Bannerlord.Warfare/_Module/ModuleData/Languages/EN/module_strings.xml
@@ -70,6 +70,7 @@
 		<string id="UxCTxfA9" text="Automatically maintains cohesion for this army using player influence" />
 		<string id="CdZaf4Ir" text="Insufficient influence to maintain cohesion for army: {ARMY}" />
 		<string id="QETGd5n6" text="Daily Influence Change: {CHANGE}{INFLUENCE_ICON}" />
+		<string id="d2GgQuYI" text="You must leave the party before becoming it's new leader." />
 		<!--Settings-->
 		<string id="Wa3DouAN" text="Warfare" />
 		<string id="EtmesuQ7" text="General" />


### PR DESCRIPTION
- Reorganized MCM settings.
- Changed tooltip text on the disband army button when disabled to acknowledge that army leaders can still manage their own armies.
- Added 'Maintain Vanilla Names' setting which prevents vanilla mercenary clans and heroes from being renamed on game start when enabled.
- Added 'Maintain Vanilla Banners' setting which prevents vanilla mercenary clans from having their banners changed on game start when enabled.
- Removed the ability to become the leader of a party the player is currently a member of, due to a bug that breaks the army overlay on the map.